### PR TITLE
Make initialisation on start optional to avoid double events

### DIFF
--- a/GestureSystem/Scripts/IGestureManager.cs
+++ b/GestureSystem/Scripts/IGestureManager.cs
@@ -6,10 +6,12 @@ namespace Cacophony
     {
         public IGestureDetector<T> gestureDetector;
         public IActionProcessor actionProcessor;
+        [Tooltip("Initialise on start only if configuring from the inspector")]
+        public bool initOnStart = false;
 
         void Start()
         {
-            if(actionProcessor != null && gestureDetector != null)
+            if(initOnStart && actionProcessor != null && gestureDetector != null)
             {
                 actionProcessor.Initialise(gestureDetector);
             }


### PR DESCRIPTION
Fixes a bug where gesture components created from code would initialise on startup as well as if you initialise manually. 

Exposed a toggle, so that you can still construct a gesture from the editor.